### PR TITLE
Fix for 360 rotations at extreme values

### DIFF
--- a/PowerCamera/src/nl/svenar/powercamera/CameraHandler.java
+++ b/PowerCamera/src/nl/svenar/powercamera/CameraHandler.java
@@ -103,6 +103,10 @@ public class CameraHandler extends BukkitRunnable {
 		return output;
 	}
 
+	private double normalizeYaw(double yaw, boolean normalize) {
+		return normalize && yaw > 180 ? (yaw - 360) : yaw;
+	}
+
 	private Location translateLinear(Location point, Location point_next, int progress, int progress_max) {
 		if (!point.getWorld().getUID().toString().equals(point_next.getWorld().getUID().toString())) {
 			return point_next;
@@ -113,6 +117,13 @@ public class CameraHandler extends BukkitRunnable {
 		new_point.setX(calculateProgress(point.getX(), point_next.getX(), progress, progress_max));
 		new_point.setY(calculateProgress(point.getY(), point_next.getY(), progress, progress_max));
 		new_point.setZ(calculateProgress(point.getZ(), point_next.getZ(), progress, progress_max));
+
+		boolean normalizeYaw = Math.abs(point.getYaw() - point_next.getYaw()) > 180;
+		new_point.setYaw((float) calculateProgress(
+				normalizeYaw(point.getYaw(), normalizeYaw),
+				normalizeYaw(point_next.getYaw(), normalizeYaw),
+				progress,
+				progress_max));
 		new_point.setYaw((float) calculateProgress(point.getYaw(), point_next.getYaw(), progress, progress_max));
 		new_point.setPitch((float) calculateProgress(point.getPitch(), point_next.getPitch(), progress, progress_max));
 


### PR DESCRIPTION
Fixes the "360" move when a camera calculates the transition from an extremely low value to a high one (e.g. yaw=20 -> yaw=340).

Essentially just checks if the yaw destination rotation is >180 degrees, and if so, normalizes the usual yaw angle range (0,360) to a range in (-180,180) so that transitions between 360->0 don't go the other (long) way around, and rather goes through 0 smoothly.  This does mean that points that change the yaw >180 degrees will now need an additional point somewhere in between.